### PR TITLE
Update Default Backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ smoke-test-local:
 
 smoke-test-cloud:
 	@echo "🔥 Running cloud smoke tests..."
-	./scripts/run_smoke_tests.sh --api-url http://localhost:8080
+	./scripts/run_smoke_tests.sh --api-url https://api.secretsnap.dev
 
 install: build
 	@echo "📦 Installing $(BINARY)..."

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ smoke-test-local:
 
 smoke-test-cloud:
 	@echo "🔥 Running cloud smoke tests..."
-	./scripts/run_smoke_tests.sh --api-url https://api.secretsnap.dev
+	./scripts/run_smoke_tests.sh --api-url http://localhost:8080
 
 install: build
 	@echo "📦 Installing $(BINARY)..."

--- a/SMOKE_TESTS.md
+++ b/SMOKE_TESTS.md
@@ -39,7 +39,7 @@ The smoke tests are designed to be as "real" as possible, using actual CLI binar
 
 1. Go 1.22+ installed
 2. CLI binary built (`make build`)
-3. Optional: API server running on `https://api.secretsnap.dev`
+3. Optional: API server running on `http://localhost:8080`
 4. Optional: Real license key in `smoke-test-license.key` file for real license tests
 
 ### Quick Start
@@ -223,11 +223,11 @@ The `TestSmokeCloudModeRealLicense` and `TestSmokeAPIRealLicense` tests run the 
 
 ## Environment Variables
 
-| Variable                 | Description              | Default                      |
-| ------------------------ | ------------------------ | ---------------------------- |
-| `DEV_SECRETSNAP_API_URL` | API server URL           | `https://api.secretsnap.dev` |
-| `SKIP_CLOUD_TESTS`       | Skip cloud-related tests | (unset)                      |
-| `SKIP_API_TESTS`         | Skip API endpoint tests  | (unset)                      |
+| Variable                 | Description              | Default                 |
+| ------------------------ | ------------------------ | ----------------------- |
+| `DEV_SECRETSNAP_API_URL` | API server URL           | `http://localhost:8080` |
+| `SKIP_CLOUD_TESTS`       | Skip cloud-related tests | (unset)                 |
+| `SKIP_API_TESTS`         | Skip API endpoint tests  | (unset)                 |
 
 ## Test Data
 

--- a/SMOKE_TESTS.md
+++ b/SMOKE_TESTS.md
@@ -39,7 +39,7 @@ The smoke tests are designed to be as "real" as possible, using actual CLI binar
 
 1. Go 1.22+ installed
 2. CLI binary built (`make build`)
-3. Optional: API server running on `localhost:8080`
+3. Optional: API server running on `https://api.secretsnap.dev`
 4. Optional: Real license key in `smoke-test-license.key` file for real license tests
 
 ### Quick Start
@@ -223,11 +223,11 @@ The `TestSmokeCloudModeRealLicense` and `TestSmokeAPIRealLicense` tests run the 
 
 ## Environment Variables
 
-| Variable             | Description              | Default                 |
-| -------------------- | ------------------------ | ----------------------- |
-| `SECRETSNAP_API_URL` | API server URL           | `http://localhost:8080` |
-| `SKIP_CLOUD_TESTS`   | Skip cloud-related tests | (unset)                 |
-| `SKIP_API_TESTS`     | Skip API endpoint tests  | (unset)                 |
+| Variable                 | Description              | Default                      |
+| ------------------------ | ------------------------ | ---------------------------- |
+| `DEV_SECRETSNAP_API_URL` | API server URL           | `https://api.secretsnap.dev` |
+| `SKIP_CLOUD_TESTS`       | Skip cloud-related tests | (unset)                      |
+| `SKIP_API_TESTS`         | Skip API endpoint tests  | (unset)                      |
 
 ## Test Data
 
@@ -292,5 +292,5 @@ The smoke tests can be integrated into CI/CD pipelines:
     cd cli
     ./scripts/run_smoke_tests.sh --local-only
   env:
-    SECRETSNAP_API_URL: ${{ secrets.API_URL }}
+    DEV_SECRETSNAP_API_URL: ${{ secrets.API_URL }}
 ```

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -682,7 +682,7 @@ func TestLicenseEnforcement(t *testing.T) {
 	}
 
 	// Test that paid commands fail without login
-	// Note: These commands will fail with connection errors because they try to connect to https://api.secretsnap.dev
+	// Note: These commands will fail with connection errors because they try to connect to http://localhost:8080
 	// The license enforcement happens in the CLI logic before the API call
 	tests := []struct {
 		name          string

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -279,8 +279,8 @@ func runCommand(t *testing.T, data *TestData, args ...string) (string, string, e
 	env = append(env, "ALLOW_ALL_LICENSES=1") // Allow fake licenses for testing
 
 	// Set API URL if provided in environment
-	if apiURL := os.Getenv("SECRETSNAP_API_URL"); apiURL != "" {
-		env = append(env, "SECRETSNAP_API_URL="+apiURL)
+	if apiURL := os.Getenv("DEV_SECRETSNAP_API_URL"); apiURL != "" {
+		env = append(env, "DEV_SECRETSNAP_API_URL="+apiURL)
 	}
 
 	// Get current directory for building
@@ -475,7 +475,7 @@ func TestPaidMode(t *testing.T) {
 	defer cleanupTestData(t, data)
 
 	// Set API URL to test server
-	os.Setenv("SECRETSNAP_API_URL", server.URL)
+	os.Setenv("DEV_SECRETSNAP_API_URL", server.URL)
 
 	tests := []struct {
 		name    string
@@ -531,7 +531,7 @@ func TestAuditLogs(t *testing.T) {
 	defer cleanupTestData(t, data)
 
 	// Set API URL to test server
-	os.Setenv("SECRETSNAP_API_URL", server.URL)
+	os.Setenv("DEV_SECRETSNAP_API_URL", server.URL)
 
 	// Login first
 	_, _, err := runCommand(t, data, "login", "--license", data.licenseKey)
@@ -682,7 +682,7 @@ func TestLicenseEnforcement(t *testing.T) {
 	}
 
 	// Test that paid commands fail without login
-	// Note: These commands will fail with connection errors because they try to connect to localhost:8080
+	// Note: These commands will fail with connection errors because they try to connect to https://api.secretsnap.dev
 	// The license enforcement happens in the CLI logic before the API call
 	tests := []struct {
 		name          string
@@ -745,7 +745,7 @@ func TestLicenseEnforcement(t *testing.T) {
 	defer server.Close()
 
 	// Set API URL to test server
-	os.Setenv("SECRETSNAP_API_URL", server.URL)
+	os.Setenv("DEV_SECRETSNAP_API_URL", server.URL)
 
 	// Login first
 	_, _, err = runCommand(t, data, "login", "--license", data.licenseKey)
@@ -805,7 +805,7 @@ func TestIntegration(t *testing.T) {
 	defer cleanupTestData(t, data)
 
 	// Set API URL to test server
-	os.Setenv("SECRETSNAP_API_URL", server.URL)
+	os.Setenv("DEV_SECRETSNAP_API_URL", server.URL)
 
 	// Complete workflow test
 	steps := []struct {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -65,6 +65,6 @@ var loginCmd = &cobra.Command{
 
 func init() {
 	loginCmd.Flags().StringVarP(&loginLicense, "license", "l", "", "License key (required)")
-	loginCmd.Flags().StringVarP(&loginAPIURL, "api-url", "", "", "API URL (default: http://localhost:8080)")
+	loginCmd.Flags().StringVarP(&loginAPIURL, "api-url", "", "", "API URL (default: https://api.secretsnap.dev)")
 	loginCmd.MarkFlagRequired("license")
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -32,8 +32,8 @@ func GetPassphrase(pass, passFile string) (string, error) {
 
 // GetAPIURL returns the API URL from environment variable or default
 func GetAPIURL() string {
-	if url := os.Getenv("SECRETSNAP_API_URL"); url != "" {
+	if url := os.Getenv("DEV_SECRETSNAP_API_URL"); url != "" {
 		return url
 	}
-	return "http://localhost:8080"
+	return "https://api.secretsnap.dev"
 }

--- a/scripts/run_smoke_tests.sh
+++ b/scripts/run_smoke_tests.sh
@@ -15,7 +15,7 @@ NC='\033[0m' # No Color
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLI_DIR="$(dirname "$SCRIPT_DIR")"
-API_URL="${SECRETSNAP_API_URL:-http://localhost:8080}"
+API_URL="${DEV_SECRETSNAP_API_URL:-https://api.secretsnap.dev}"
 SKIP_CLOUD_TESTS="${SKIP_CLOUD_TESTS:-}"
 SKIP_API_TESTS="${SKIP_API_TESTS:-}"
 
@@ -82,7 +82,7 @@ run_tests() {
     cd "$CLI_DIR"
     
     # Set environment variables for tests
-    export SECRETSNAP_API_URL="$API_URL"
+    export DEV_SECRETSNAP_API_URL="$API_URL"
     export SKIP_CLOUD_TESTS="$SKIP_CLOUD_TESTS"
     export SKIP_API_TESTS="$SKIP_API_TESTS"
     
@@ -102,7 +102,7 @@ run_specific_test() {
     cd "$CLI_DIR"
     
     # Set environment variables for tests
-    export SECRETSNAP_API_URL="$API_URL"
+    export DEV_SECRETSNAP_API_URL="$API_URL"
     export SKIP_CLOUD_TESTS="$SKIP_CLOUD_TESTS"
     export SKIP_API_TESTS="$SKIP_API_TESTS"
     
@@ -123,7 +123,7 @@ Usage: $0 [OPTIONS] [TEST_NAME]
 
 Options:
     -h, --help          Show this help message
-    --api-url URL       Set API server URL (default: http://localhost:8080)
+    --api-url URL       Set API server URL (default: https://api.secretsnap.dev)
     --skip-cloud        Skip cloud-related tests
     --skip-api          Skip API endpoint tests
     --local-only        Run only local mode tests
@@ -135,7 +135,7 @@ Examples:
     $0 --api-url http://localhost:9000  # Use custom API URL
 
 Environment Variables:
-    SECRETSNAP_API_URL   API server URL
+    DEV_SECRETSNAP_API_URL   API server URL
     SKIP_CLOUD_TESTS     Skip cloud tests if set to 1
     SKIP_API_TESTS       Skip API tests if set to 1
 

--- a/scripts/run_smoke_tests.sh
+++ b/scripts/run_smoke_tests.sh
@@ -15,7 +15,7 @@ NC='\033[0m' # No Color
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLI_DIR="$(dirname "$SCRIPT_DIR")"
-API_URL="${DEV_SECRETSNAP_API_URL:-https://api.secretsnap.dev}"
+API_URL="${DEV_SECRETSNAP_API_URL:-http://localhost:8080}"
 SKIP_CLOUD_TESTS="${SKIP_CLOUD_TESTS:-}"
 SKIP_API_TESTS="${SKIP_API_TESTS:-}"
 
@@ -123,7 +123,7 @@ Usage: $0 [OPTIONS] [TEST_NAME]
 
 Options:
     -h, --help          Show this help message
-    --api-url URL       Set API server URL (default: https://api.secretsnap.dev)
+    --api-url URL       Set API server URL (default: http://localhost:8080)
     --skip-cloud        Skip cloud-related tests
     --skip-api          Skip API endpoint tests
     --local-only        Run only local mode tests

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -57,7 +57,7 @@ func setupSmokeTest(t *testing.T) *SmokeTestData {
 	cliPath = absPath
 
 	// Determine API URL
-	apiURL := "https://api.secretsnap.dev"
+	apiURL := "http://localhost:8080"
 	if envURL := os.Getenv("DEV_SECRETSNAP_API_URL"); envURL != "" {
 		apiURL = envURL
 	}

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -57,8 +57,8 @@ func setupSmokeTest(t *testing.T) *SmokeTestData {
 	cliPath = absPath
 
 	// Determine API URL
-	apiURL := "http://localhost:8080"
-	if envURL := os.Getenv("SECRETSNAP_API_URL"); envURL != "" {
+	apiURL := "https://api.secretsnap.dev"
+	if envURL := os.Getenv("DEV_SECRETSNAP_API_URL"); envURL != "" {
 		apiURL = envURL
 	}
 
@@ -90,7 +90,7 @@ func runSmokeCommand(t *testing.T, data *SmokeTestData, args ...string) (string,
 
 	cmd := exec.Command(data.cliPath, args...)
 	cmd.Dir = data.tempDir
-	cmd.Env = append(os.Environ(), "SECRETSNAP_API_URL="+data.apiURL)
+	cmd.Env = append(os.Environ(), "DEV_SECRETSNAP_API_URL="+data.apiURL)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
**Description**
Update API configuration from localhost development to production cloud endpoints. This change updates the default API URL from `http://localhost:8080` to `https://api.secretsnap.dev` and renames the environment variable from `SECRETSNAP_API_URL` to `DEV_SECRETSNAP_API_URL` for better clarity between development and production environments.

**Type of Change**

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

**Testing**

- [ ] Added tests for new functionality
- [x] All tests pass
- [x] Manual testing completed

**Checklist**

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No breaking changes (or documented)

**Key Changes:**
- Updated default API URL from `http://localhost:8080` to `https://api.secretsnap.dev`
- Renamed environment variable `SECRETSNAP_API_URL` to `DEV_SECRETSNAP_API_URL`
- Updated all test files, documentation, and scripts to use the new configuration
- Updated login command help text to reflect new default API URL
- Modified smoke test documentation and scripts to use new environment variable naming

This change ensures the CLI points to the production API by default while maintaining the ability to override for development using the `DEV_SECRETSNAP_API_URL` environment variable.